### PR TITLE
Fix for possible crash

### DIFF
--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -374,6 +374,8 @@ unsigned JsVlcPlayer::video_format_cb( char* chroma,
                                                         width, height,
                                                         pitches, lines,
                                                         &asyncData );
+    _jsRawFrameBuffer = nullptr;
+
     if( asyncData ) {
         _asyncDataGuard.lock();
         _asyncData.push_back( asyncData );

--- a/src/JsVlcPlayer.cpp
+++ b/src/JsVlcPlayer.cpp
@@ -386,6 +386,7 @@ unsigned JsVlcPlayer::video_format_cb( char* chroma,
 
 void JsVlcPlayer::video_cleanup_cb()
 {
+    _jsRawFrameBuffer = nullptr;
     _videoFrame->video_cleanup_cb();
 
     _asyncDataGuard.lock();


### PR DESCRIPTION
Nothing really to comment here :)

Fixes issue #14 

setupBuffer is called asynchronously, so it waits for it's turn in the event loop :)

In apps like Stremio, when the event loop is heavily used, especially when P2P streaming is enabled, setupBuffer can get called after video_lock_cb.

If there is a jsRawFrameBuffer left from a previous video, and setupBuffer is not called yet to re-init it with a new size, we will draw in the old one (because of the logic in video_lock_cb) and get an overflow. BOOM.