### PR TITLE
Fixed memcpy and memset errors on Ubuntu 15.04. Electron version to 0.31.1

### DIFF
--- a/build_electron.sh
+++ b/build_electron.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 export npm_config_wcjs_runtime="electron"
-export npm_config_wcjs_runtime_version="0.30.6"
+export npm_config_wcjs_runtime_version="0.31.1"
 
 npm install

--- a/src/VlcVideoOutput.cpp
+++ b/src/VlcVideoOutput.cpp
@@ -43,7 +43,7 @@ unsigned VlcVideoOutput::RV32VideoFrame::video_format_cb( char* chroma,
     _width = *width;
     _height = *height;
 
-    memcpy( chroma, vlc::DEF_CHROMA, sizeof( vlc::DEF_CHROMA ) - 1 );
+    std::memcpy( chroma, vlc::DEF_CHROMA, sizeof( vlc::DEF_CHROMA ) - 1 );
     *pitches = *width * vlc::DEF_PIXEL_BYTES;
     *lines = *height;
 
@@ -62,7 +62,7 @@ void* VlcVideoOutput::RV32VideoFrame::video_lock_cb( void** planes )
 void VlcVideoOutput::RV32VideoFrame::fillBlack()
 {
     if( _frameBuffer ) {
-        memset( _frameBuffer, 0, size() );
+        std::memset( _frameBuffer, 0, size() );
     }
 }
 
@@ -81,7 +81,7 @@ unsigned VlcVideoOutput::I420VideoFrame::video_format_cb( char* chroma,
 
     const char CHROMA[] = "I420";
 
-    memcpy( chroma, CHROMA, sizeof( CHROMA ) - 1 );
+    std::memcpy( chroma, CHROMA, sizeof( CHROMA ) - 1 );
 
     const unsigned evenWidth = *width + ( *width & 1 );
     const unsigned evenHeight = *height + ( *height & 1 );
@@ -124,9 +124,9 @@ void VlcVideoOutput::I420VideoFrame::fillBlack()
 {
     if( _frameBuffer ) {
         char* buffer = static_cast<char*>( _frameBuffer );
-        memset( buffer, 0x0, _uPlaneOffset );
-        memset( buffer + _uPlaneOffset, 0x80, _vPlaneOffset - _uPlaneOffset );
-        memset( buffer + _vPlaneOffset, 0x80, size() - _vPlaneOffset );
+        std::memset( buffer, 0x0, _uPlaneOffset );
+        std::memset( buffer + _uPlaneOffset, 0x80, _vPlaneOffset - _uPlaneOffset );
+        std::memset( buffer + _vPlaneOffset, 0x80, size() - _vPlaneOffset );
     }
 }
 

--- a/src/VlcVideoOutput.h
+++ b/src/VlcVideoOutput.h
@@ -4,10 +4,9 @@
 #include <memory>
 #include <mutex>
 #include <atomic>
-
 #include <uv.h>
-
 #include <libvlc_wrapper/vlc_vmem.h>
+#include <cstring>
 
 ///////////////////////////////////////////////////////////////////////////////
 class VlcVideoOutput :


### PR DESCRIPTION
I got errors from memcpy and memset when building on Ubuntu. It works after this fix.