### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ libvlc binding for node.js/io.js/NW.js/Electron
 
 ### Using prebuilt on Linux
 * install `VLC` (for apt based distros: `sudo apt-get install vlc`)
-* `npm install WebChimera.js --ignore-scripts`
+* `npm install webchimera.js --ignore-scripts`
 * download `WebChimera.js_*_linux.zip` and extract to `webchimera.js\Release`
 
 ## Build Prerequisites


### PR DESCRIPTION
Packages are no longer allowed to have a capital in their name, trying to install WebChimera results in an error.